### PR TITLE
Simplified Sidebar

### DIFF
--- a/docs/using-a-listview.md
+++ b/docs/using-a-listview.md
@@ -5,6 +5,8 @@ title: Using List Views
 
 React Native provides a suite of components for presenting lists of data. Generally, you'll want to use either [FlatList](flatlist.md) or [SectionList](sectionlist.md).
 
+### FlatList
+
 The `FlatList` component displays a scrolling list of changing, but similarly structured, data. `FlatList` works well for long lists of data, where the number of items might change over time. Unlike the more generic [`ScrollView`](using-a-scrollview.md), the `FlatList` only renders elements that are currently showing on the screen, not all the elements at once.
 
 The `FlatList` component requires two props: `data` and `renderItem`. `data` is the source of information for the list. `renderItem` takes one item from the source and returns a formatted component to render.
@@ -51,6 +53,8 @@ const styles = StyleSheet.create({
   },
 })
 ```
+
+### SectionList
 
 If you want to render a set of data broken into logical sections, maybe with section headers, similar to `UITableView`s on iOS, then a [SectionList](sectionlist.md) is the way to go.
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -3501,20 +3501,14 @@
     },
     "categories": {
       "The Basics": "The Basics",
+      "Guides": "Guides",
       "Environment setup": "Environment setup",
       "Workflow": "Workflow",
-      "Design": "Design",
-      "Interaction": "Interaction",
-      "Inclusion": "Inclusion",
-      "Performance": "Performance",
-      "JavaScript Runtime": "JavaScript Runtime",
-      "Connectivity": "Connectivity",
       "Native Components and Modules": "Native Components and Modules",
       "Guides (iOS)": "Guides (iOS)",
       "Guides (Android)": "Guides (Android)",
       "Components": "Components",
       "APIs": "APIs",
-      "Guides": "Guides",
       "Contributing": "Contributing"
     }
   },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -7,12 +7,42 @@
       "handling-text-input",
       "using-a-scrollview",
       "using-a-listview",
-      "troubleshooting",
-      "platform-specific-code",
+      "network",
       "more-resources"
+    ],
+    "Guides": [
+      {
+        "type": "subcategory",
+        "label": "Design",
+        "ids": ["style", "height-and-width", "flexbox", "images", "colors"]
+      },
+      {
+        "type": "subcategory",
+        "label": "Interaction",
+        "ids": [
+          "handling-touches",
+          "navigation",
+          "animations",
+          "gesture-responder-system"
+        ]
+      },
+      {
+        "type": "subcategory",
+        "label": "Inclusion",
+        "ids": ["accessibility"]
+      },
+      {
+        "type": "subcategory",
+        "label": "Performance",
+        "ids": ["performance", "hermes", "optimizing-flatlist-configuration"]
+      },
+      "timers",
+      "javascript-environment",
+      "platform-specific-code"
     ],
     "Environment setup": [
       "getting-started",
+      "troubleshooting",
       "integration-with-existing-apps",
       "building-for-apple-tv",
       "out-of-tree-platforms"
@@ -24,17 +54,6 @@
       "typescript",
       "upgrading"
     ],
-    "Design": ["style", "height-and-width", "flexbox", "images", "colors"],
-    "Interaction": [
-      "handling-touches",
-      "navigation",
-      "animations",
-      "gesture-responder-system"
-    ],
-    "Inclusion": ["accessibility"],
-    "Performance": ["performance", "optimizing-flatlist-configuration"],
-    "JavaScript Runtime": ["javascript-environment", "timers", "hermes"],
-    "Connectivity": ["network"],
     "Native Components and Modules": [
       "native-modules-setup",
       "direct-manipulation"

--- a/website/static/css/toc.css
+++ b/website/static/css/toc.css
@@ -99,3 +99,40 @@
     padding-top: 2rem;
   }
 }
+
+/** SubNavGroup **/
+.toc .toggleNav ul .subNavGroup .navItem {
+  padding-left: 16px;
+}
+
+.toc .toggleNav .navGroup .subNavGroup .navListItem::before {
+  content: "";
+  position: absolute;
+  left: 2px;
+  top: 0px;
+  bottom: 0px;
+  border-left: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.toc .toggleNav .navGroup .subNavGroup .navGroupSubcategoryTitle {
+  font-weight: 600;
+}
+
+.toc .toggleNav ul .subNavGroup li.navListItemActive::before {
+  content: "";
+  background-color: inherit;
+  position: absolute;
+  width: 5px;
+  top: 2px;
+  left: -20px;
+  bottom: 2px;
+}
+
+.toc .toggleNav ul .subNavGroup li.navListItemActive::after {
+  content: "";
+  background-color: $brand;
+  position: absolute;
+  width: 5px;
+  top: 2px;
+  bottom: 2px;
+}


### PR DESCRIPTION
# Description
I just saw the new docs and loved them, docs are so much easier to read ❤️. I noticed there are many first level categorizations which makes it a little bit harder to read them as a continuos flow.  "The basics" was a total blast to read continuosly but after it I felt I had to start jumping around a bit to continue the lecture, this aims to solve that.

The sidebar would end up looking like this: 

| Collapsed | Expanded |
| ------------- | ------------- |
| <img width="1440" alt="Captura de pantalla 2020-01-25 a la(s) 14 29 51" src="https://user-images.githubusercontent.com/8615216/73125045-3756fc00-3f81-11ea-9647-e06834c31fdc.png">  | <img width="1440" alt="Captura de pantalla 2020-01-25 a la(s) 14 29 32" src="https://user-images.githubusercontent.com/8615216/73125066-7d13c480-3f81-11ea-8bf1-f037138297d0.png"> |

# Changes
- Moved "Network" into "The Basics"
- Moved "Troubleshooting" from "The Basics" to "Environment Setup"
- Added titles to "Using List Views" readme (easier to classify the contents it has)
- Removed "Design", "Interaction", "Accessibility" and "Performance" from first level and moved it instead into "Guides"
- Moved "Hermes" into "Performance" due to its content
- Moved timers out of "Javascript Environment" and placed it instead as a "Guide" since before it obfuscated finding it and it's a common feature at least from a userland perspective
- Added styles for subgroups to ease classification

# TBD
- I'm not entirely sure of the first level title "Guides". Let me know what you think, I also thought of "Advanced" or "Excel" (which is used by next [here](https://nextjs.org/learn/basics/create-dynamic-pages/use-router))

Hope it helps :)





